### PR TITLE
feat(): Support for half-circle and multiple scalar values

### DIFF
--- a/src/confetti.js
+++ b/src/confetti.js
@@ -334,6 +334,10 @@
       context.ellipse ?
         context.ellipse(fetti.x, fetti.y, Math.abs(x2 - x1) * fetti.ovalScalar, Math.abs(y2 - y1) * fetti.ovalScalar, Math.PI / 10 * fetti.wobble, 0, 2 * Math.PI) :
         ellipse(context, fetti.x, fetti.y, Math.abs(x2 - x1) * fetti.ovalScalar, Math.abs(y2 - y1) * fetti.ovalScalar, Math.PI / 10 * fetti.wobble, 0, 2 * Math.PI);
+    } else if (fetti.shape === 'half-circle') {
+      context.ellipse ?
+        context.ellipse(fetti.x, fetti.y, Math.abs(x2 - x1) * fetti.ovalScalar, Math.abs(y2 - y1) * fetti.ovalScalar, Math.PI / 10 * fetti.wobble, 0, Math.PI) :
+        ellipse(context, fetti.x, fetti.y, Math.abs(x2 - x1) * fetti.ovalScalar, Math.abs(y2 - y1) * fetti.ovalScalar, Math.PI / 10 * fetti.wobble, 0, Math.PI);
     } else {
       context.moveTo(Math.floor(fetti.x), Math.floor(fetti.y));
       context.lineTo(Math.floor(fetti.wobbleX), Math.floor(y1));

--- a/src/confetti.js
+++ b/src/confetti.js
@@ -190,7 +190,7 @@
     ],
     // probably should be true, but back-compat
     disableForReducedMotion: false,
-    scalar: 1
+    scalar: [1]
   };
 
   function convert(val, transform) {
@@ -457,7 +457,7 @@
             decay: decay,
             gravity: gravity,
             drift: drift,
-            scalar: scalar
+            scalar: scalar[randomInt(0, scalar.length)]
           })
         );
       }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -347,7 +347,7 @@ test('shoots larger scaled confetti', async t => {
   t.context.buffer = await confettiImage(page, {
     colors: ['#0000ff'],
     shapes: ['circle'],
-    scalar: 10,
+    scalar: [10],
     particleCount: 10
   });
   t.context.image = await removeOpacity(t.context.buffer);


### PR DESCRIPTION
Made simple changes to support half-circle shape and changed scalar to take a list instead of a single value to support different types of confetti sizes